### PR TITLE
Fifo properties

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "dependencies/nlohmann_json/json"]
 	path = dependencies/nlohmann_json/json
 	url = https://github.com/nlohmann/json.git
+[submodule "dependencies/fifo_map/fifo_map"]
+	path = dependencies/fifo_map/fifo_map
+	url = https://github.com/nlohmann/fifo_map.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,8 @@ LINK_DIRECTORIES(${Boost_LIBRARY_DIRS})
 
 # nlohmann_json
 add_subdirectory(dependencies/nlohmann_json)
+add_subdirectory(dependencies/fifo_map)
+INCLUDE_DIRECTORIES(dependencies/fifo_map/fifo_map/src)
 
 FIND_PACKAGE(Threads)
 

--- a/dependencies/fifo_map/CMakeLists.txt
+++ b/dependencies/fifo_map/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.2)
+
+add_subdirectory("fifo_map" EXCLUDE_FROM_ALL)

--- a/src/jschema.cpp
+++ b/src/jschema.cpp
@@ -3,7 +3,7 @@
 #include <tcd.h>
 
 using namespace libxtide;
-#include "json_fifo.h"
+
 
 json& addProperty(json& parent, const char* propertyName, const char* type,  const char* description = NULL) {
 

--- a/src/jschema.cpp
+++ b/src/jschema.cpp
@@ -3,7 +3,7 @@
 #include <tcd.h>
 
 using namespace libxtide;
-using json = nlohmann::json;
+#include "json_fifo.h"
 
 json& addProperty(json& parent, const char* propertyName, const char* type,  const char* description = NULL) {
 

--- a/src/jschema.h
+++ b/src/jschema.h
@@ -2,7 +2,7 @@
 #define _jschema_H
 
 #include <memory>
-#include <nlohmann/json.hpp>
+#include "json_fifo.h"
 
 /**
   * jschema.h
@@ -40,7 +40,7 @@
  * in the jsonxt.h module.  If the XTide data file can not be opened, the passed
  * object will remain unchanged.
  */
-extern void getJsonSchema(nlohmann::json& schema);
+extern void getJsonSchema(json& schema);
 
 
 #endif

--- a/src/json_fifo.h
+++ b/src/json_fifo.h
@@ -1,3 +1,5 @@
+#ifndef _json_fifo_h
+#define _json_fifo_h
 // This is a workaround/hack to allow nlohmann::json objects to have properties be output in First In/First Out order vs the
 // alphabetized order which is the default behavior.  This hack is based on this issue filed on GitHub:
 // https://github.com/nlohmann/json/issues/485#issuecomment-333652309
@@ -9,4 +11,5 @@
 template<class K, class V, class dummy_compare, class A>
 using my_workaround_fifo_map = nlohmann::fifo_map<K, V, nlohmann::fifo_map_compare<K>, A>;
 using json = nlohmann::basic_json<my_workaround_fifo_map>;
+#endif
 

--- a/src/json_fifo.h
+++ b/src/json_fifo.h
@@ -1,0 +1,12 @@
+// This is a workaround/hack to allow nlohmann::json objects to have properties be output in First In/First Out order vs the
+// alphabetized order which is the default behavior.  This hack is based on this issue filed on GitHub:
+// https://github.com/nlohmann/json/issues/485#issuecomment-333652309
+//
+#include <nlohmann/json.hpp>
+#include <fifo_map.hpp>
+
+
+template<class K, class V, class dummy_compare, class A>
+using my_workaround_fifo_map = nlohmann::fifo_map<K, V, nlohmann::fifo_map_compare<K>, A>;
+using json = nlohmann::basic_json<my_workaround_fifo_map>;
+

--- a/src/jsonxt.cpp
+++ b/src/jsonxt.cpp
@@ -7,7 +7,6 @@
 
 using namespace std;
 using namespace libxtide;
-#include "json_fifo.h"
 
 
 void tojson(libxtide::Coordinates coord, json& j) {

--- a/src/jsonxt.cpp
+++ b/src/jsonxt.cpp
@@ -7,7 +7,7 @@
 
 using namespace std;
 using namespace libxtide;
-using json = nlohmann::json;
+#include "json_fifo.h"
 
 
 void tojson(libxtide::Coordinates coord, json& j) {

--- a/src/jsonxt.h
+++ b/src/jsonxt.h
@@ -2,7 +2,7 @@
 #define _jsonxt_H_
 
 #include <memory>
-#include <nlohmann/json.hpp>
+#include "json_fifo.h"
 
 #include "_libxtide.h"
 
@@ -38,7 +38,7 @@
  * Sets the lat and long properies of j to
  * the specified coordinates.
  */
-extern void tojson(libxtide::Coordinates coord, nlohmann::json& j);
+extern void tojson(libxtide::Coordinates coord, json& j);
 
 
 
@@ -46,7 +46,7 @@ extern void tojson(libxtide::Coordinates coord, nlohmann::json& j);
  * Populates the json member j.position with the
  * specified coordinates.
  */
-extern void setPosition(libxtide::Coordinates coord, nlohmann::json& j);
+extern void setPosition(libxtide::Coordinates coord, json& j);
 
 
 
@@ -54,14 +54,14 @@ extern void setPosition(libxtide::Coordinates coord, nlohmann::json& j);
  * Populates the json object j with data from
  * the station reference pRef.
  */
-extern void tojson(libxtide::StationRef* pRef, nlohmann::json& j);
+extern void tojson(libxtide::StationRef* pRef, json& j);
 
 
 /**
  * Populates the json object j with data from
  * the station pStat.
  */
-extern void tojson(libxtide::Station* pStat, libxtide::StationRef* pRef, nlohmann::json& j);
+extern void tojson(libxtide::Station* pStat, libxtide::StationRef* pRef, json& j);
 
 
 
@@ -69,7 +69,7 @@ extern void tojson(libxtide::Station* pStat, libxtide::StationRef* pRef, nlohman
  * Populates the specified json object with
  * event data from TideEvent
  */
-extern void tojson(libxtide::TideEvent& event, nlohmann::json& j);
+extern void tojson(libxtide::TideEvent& event, json& j);
 
 
 
@@ -78,7 +78,7 @@ extern void tojson(libxtide::TideEvent& event, nlohmann::json& j);
  * tide events specified in eventList;
  */
 
-extern void setEvents(libxtide::TideEventsOrganizer& eventList, nlohmann::json& j, Dstr* pTimeZone);
+extern void setEvents(libxtide::TideEventsOrganizer& eventList, json& j, Dstr* pTimeZone);
 
 
 
@@ -87,7 +87,7 @@ extern void setEvents(libxtide::TideEventsOrganizer& eventList, nlohmann::json& 
  * Returns a populated json object with the tide or current prediction harmonics
  * data for the specified station Id.
  */
-extern void getStationHarmonicsAsJson(int stationId, nlohmann::json& j);
+extern void getStationHarmonicsAsJson(int stationId, json& j);
 
 
 
@@ -96,6 +96,6 @@ extern void getStationHarmonicsAsJson(int stationId, nlohmann::json& j);
  * definition stored in j.  TRUE is returned if the write was successful.  status
  * will be populated with a return code and a message string.
  */
-extern bool setStationHarmonicsFromJson(nlohmann::json& j, nlohmann::json& status);
+extern bool setStationHarmonicsFromJson(json& j, json& status);
 
 #endif

--- a/src/jutil.hpp
+++ b/src/jutil.hpp
@@ -7,10 +7,9 @@
 // Joel Kozikowski
 
 
-#include <nlohmann/json.hpp>
+#include "json_fifo.h"
 
-
-void setString(char* str, int strSize, nlohmann::json& j, const char* propertyName) {
+void setString(char* str, int strSize, json& j, const char* propertyName) {
     if (j.count(propertyName)) {
         strncpy(str, j[propertyName].get<std::string>().c_str(), strSize);
         // Guarantee str is zero terminated...
@@ -22,7 +21,7 @@ void setString(char* str, int strSize, nlohmann::json& j, const char* propertyNa
 }
 
 
-int getInt(nlohmann::json& j, const char* propertyName) {
+int getInt(json& j, const char* propertyName) {
 
     if (j.count(propertyName) && j[propertyName].is_number()) {
         return j[propertyName].get<int>();
@@ -34,7 +33,7 @@ int getInt(nlohmann::json& j, const char* propertyName) {
 }
 
 
-double getNum(nlohmann::json& j, const char* propertyName) {
+double getNum(json& j, const char* propertyName) {
 
     if (j.count(propertyName) &&  j[propertyName].is_number()) {
         return j[propertyName].get<double>();
@@ -46,7 +45,7 @@ double getNum(nlohmann::json& j, const char* propertyName) {
 }
 
 
-bool getBool(nlohmann::json& j, const char* propertyName) {
+bool getBool(json& j, const char* propertyName) {
 
     if (j.count(propertyName) &&  j[propertyName].is_boolean()) {
         return j[propertyName].get<bool>();
@@ -57,7 +56,7 @@ bool getBool(nlohmann::json& j, const char* propertyName) {
 }
 
 
-std::string getStr(nlohmann::json& j, const char* propertyName) {
+std::string getStr(json& j, const char* propertyName) {
 
     if (j.count(propertyName)) {
         return j[propertyName].get<std::string>();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,7 @@
 
 using namespace std;
 using namespace libxtide;
-using json = nlohmann::json;
+#include "json_fifo.h"
 
 /**
   * main.cpp

--- a/src/util/httpclient.cpp
+++ b/src/util/httpclient.cpp
@@ -60,8 +60,8 @@ string HttpClient::Response::getBody() {
 }
 
 
-nlohmann::json HttpClient::Response::asJson() {
-   return nlohmann::json::parse(this->getBody());
+json HttpClient::Response::asJson() {
+   return json::parse(this->getBody());
 }
 
 
@@ -104,7 +104,7 @@ std::shared_ptr<HttpClient::Response> HttpClient::post(const string& path, const
 }
 
 
-std::shared_ptr<HttpClient::Response> HttpClient::post(const string& path, const nlohmann::json& body) {
+std::shared_ptr<HttpClient::Response> HttpClient::post(const string& path, const json& body) {
     setRequestHeader(http::field::content_type, "application/json");
     return post(path, body.dump());
 }

--- a/src/util/httpclient.h
+++ b/src/util/httpclient.h
@@ -8,7 +8,7 @@
 
 #include <string>
 #include <boost/beast/http.hpp>
-#include <nlohmann/json.hpp>
+#include "../json_fifo.h"
 
 
 class HttpClient {
@@ -47,7 +47,7 @@ class HttpClient {
                /**
                 * Converts the body of this response into a json object 
                 */
-               nlohmann::json asJson();
+               json asJson();
         };
 
         HttpClient(const char* host, const char* protocol = "http", const char* port = NULL);
@@ -74,7 +74,7 @@ class HttpClient {
          * request.  The content type header is set to "application/json" before the post
          * is made.
          */
-        std::shared_ptr<Response> post(const std::string& path, const nlohmann::json& body);
+        std::shared_ptr<Response> post(const std::string& path, const json& body);
 
 
         /**

--- a/src/util/nos2xt.cpp
+++ b/src/util/nos2xt.cpp
@@ -41,7 +41,7 @@
 
 #include "../jutil.hpp"
 
-using json = nlohmann::json;
+#include "../json_fifo.h"
 
 
 using namespace std;


### PR DESCRIPTION
Use fifo_map class as basis for json objects to allow order of json properties to maintain insertion order.